### PR TITLE
Added a requirements.txt to make usage easier

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+ipaddr
+pygeoip


### PR DESCRIPTION
Hi, thanks for the nice tool. I added a `requirements.txt` to make using it easier.

Typical install instruction would then be:

    virtualenv env
    pip install -r requirements.txt

And no more requirements discovery by trial and error.